### PR TITLE
Update to laravel-serializeable2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=8.0 <9.0",
         "psr/container": "^1.0|^2.0",
-        "laravel/serializable-closure": "^1.3"
+        "laravel/serializable-closure": "^2"
     },
     "suggest": {
         "psr/log": "To enable logging for compiled containers"


### PR DESCRIPTION
Could not see any relevant breaking change relevant for hbcontainer,, but it gives better support for 8.4. 

https://github.com/laravel/serializable-closure/releases/tag/v2.0.0

https://github.com/laravel/serializable-closure/releases